### PR TITLE
Fix kwargs handling at searchtags

### DIFF
--- a/erppeek.py
+++ b/erppeek.py
@@ -296,7 +296,11 @@ def issearchdomain(arg):
 def searchargs(params, kwargs=None, context=None):
     """Compute the 'search' parameters."""
     if not params:
-        return ([],)
+        return ([],
+                kwargs.pop('offset', 0),
+                kwargs.pop('limit', None),
+                kwargs.pop('order', None),
+                context)
     domain = params[0]
     if not isinstance(domain, list):
         return params


### PR DESCRIPTION
If no search_params are passed, ensure to handle kwargs and context.

So far, there's a bug that if no search_params are passed, other possible arguments are discarted.

//No issue is created due this functionality is not activated in this repo.